### PR TITLE
adjust build_env PATHs in cmake and pkgconfig files

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -89,6 +89,16 @@ ctest -VV --output-on-failure || true
 for fname in `ls ${PREFIX}/lib/cmake/netCDF/*`; do
     sed -i.bak "s#${CONDA_BUILD_SYSROOT}/usr/lib/lib\([a-z]*\).so#\1#g" ${fname}
     sed -i.bak "s#/Applications/Xcode_.*app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.*sdk/usr/lib/lib\([a-z]*\).dylib#\1#g" ${fname}
+    sed -i.bak "s#${BUILD_PREFIX}/bin/##g" ${fname}
+    rm ${fname}.bak
+    cat ${fname}
+done
+
+# Fix build paths in pkg-config artifacts
+for fname in `ls ${PREFIX}/lib/pkgconfig/*.pc`; do
+    sed -i.bak "s#${CONDA_BUILD_SYSROOT}/usr/lib/lib\([a-z]*\).so#\1#g" ${fname}
+    sed -i.bak "s#/Applications/Xcode_.*app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.*sdk/usr/lib/lib\([a-z]*\).dylib#\1#g" ${fname}
+    sed -i.bak "s#${BUILD_PREFIX}/bin/##g" ${fname}
     rm ${fname}.bak
     cat ${fname}
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     - patches/0010-pr2094.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # C has good backcompat, C++ has poor.  Since we only build C, go with good
     #   https://abi-laboratory.pro/tracker/timeline/netcdf/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,8 +57,9 @@ requirements:
     - {{ compiler('cxx') }}
     # not sure if we need fortran compiler here - seems to be presently disabled.
     # - {{ compiler('fortran') }}
-    - unzip  # [not win]
+    - unzip     # [not win]
     - m2-unzip  # [win]
+    - sed       # [unix]
   host:
     - msinttypes  # [win and vc<14]
     - bzip2


### PR DESCRIPTION
fix .pc and cmake files to not contain any build-environment paths anymore, which might confuse dependent builds