### PR TITLE
Rebuild for both OpenSSL 1 and 3 and replace curl with libcurl in run dependencies

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  jcmorin-ana-org: pdal
-
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  jcmorin-ana-org: pdal
+
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     - patches/0010-pr2094.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # C has good backcompat, C++ has poor.  Since we only build C, go with good
     #   https://abi-laboratory.pro/tracker/timeline/netcdf/
@@ -70,11 +70,11 @@ requirements:
     - libzip 1.8.0
     - openssl {{ openssl }}  # [not win]
   run:
-    - curl
+    - libcurl
     - hdf4
     - hdf5
     - libzip
-    - openssl 3.*  # [not win]
+    - openssl  # [not win]
     - zlib
 
 about:


### PR DESCRIPTION
Rebuild for both OpenSSL 1 and 3 and replace curl with libcurl in run dependencies.

This fixes inconsistencies on dependencies.